### PR TITLE
bugfix: shebang for larson_json_to_vars needs bash, not sh

### DIFF
--- a/bin/larson_json_to_vars
+++ b/bin/larson_json_to_vars
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 JSON_FILE=${1:-}
 if [[ -z "$JSON_FILE" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ DEV_DEPENDENCIES = ["black", "isort", "twine", "pytest"]
 
 setup(
     name="larson",
-    version="2.0.0",
+    version="2.0.1",
     description="Library for managing secrets",
     url="https://github.com/pbs/larson",
     author="PBS",


### PR DESCRIPTION
specifically, `[[` is a bash built-in, not a sh built-in. To keep it simple, requiring bash.